### PR TITLE
Bugfix/misc

### DIFF
--- a/docker_ELK/images/elasticsearch/Dockerfile
+++ b/docker_ELK/images/elasticsearch/Dockerfile
@@ -1,2 +1,0 @@
-ARG elastic_version
-FROM docker.elastic.co/elasticsearch/elasticsearch:${elastic_version}

--- a/docker_ELK/images/kibana/Dockerfile
+++ b/docker_ELK/images/kibana/Dockerfile
@@ -1,2 +1,0 @@
-ARG elastic_version
-FROM docker.elastic.co/kibana/kibana:${elastic_version}

--- a/docker_ELK/images/logstash/pipeline/logstash.conf
+++ b/docker_ELK/images/logstash/pipeline/logstash.conf
@@ -24,6 +24,6 @@ filter {
 output {
     elasticsearch {
         hosts => ["elasticsearch:9200"]
-        index => "test_date_parsing_2"
+        index => "logstash"
     }
 }

--- a/docker_ELK/topology/.env
+++ b/docker_ELK/topology/.env
@@ -1,1 +1,1 @@
-elastic_version=7.8.0
+elastic_version=7.8.1

--- a/docker_ELK/topology/.env
+++ b/docker_ELK/topology/.env
@@ -1,0 +1,1 @@
+elastic_version=7.8.0

--- a/docker_ELK/topology/docker-compose.yml
+++ b/docker_ELK/topology/docker-compose.yml
@@ -4,39 +4,32 @@ services:
 
   elasticsearch:
     container_name: elsearch
-    build: 
-            context: ../images/elasticsearch
-            args: 
-                    elastic_version: 7.8.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:${elastic_version}
     environment:
-            discovery.type: "single-node"
+      discovery.type: "single-node"
     ports:
       - 9200:9200
       - 9300:9300
 
   kibana:
     container_name: kib
-    build:
-            context: ../images/kibana
-            args:
-                    elastic_version: 7.8.0
-    links: 
+    image: docker.elastic.co/kibana/kibana:${elastic_version}
+    links:
       - "elasticsearch"
     ports:
-     - 5601:5601
+      - 5601:5601
     depends_on:
       - elasticsearch
 
   logstash:
     container_name: logst
     build:
-            context: ../images/logstash
-            args:
-                    elastic_version: 7.8.0
+      context: ../images/logstash
+      args:
+        - elastic_version
     ports:
       - 5044:5044
       - 5045:5045
     depends_on:
       - elasticsearch
       - kibana
-

--- a/docker_field/images/filebeat/Dockerfile
+++ b/docker_field/images/filebeat/Dockerfile
@@ -3,4 +3,5 @@ FROM docker.elastic.co/beats/filebeat:${elastic_version}
 COPY config/filebeat.yml /usr/share/filebeat/filebeat.yml
 USER root
 RUN chown root:filebeat /usr/share/filebeat/filebeat.yml
+RUN chmod go-w /usr/share/filebeat/filebeat.yml
 USER filebeat

--- a/docker_field/images/filebeat/config/filebeat.yml
+++ b/docker_field/images/filebeat/config/filebeat.yml
@@ -3,7 +3,6 @@ filebeat.inputs:
     enabled: true
     paths:
             - /usr/share/filebeat/logs/GridEye_sim.log
-  
-  
+
 output.logstash:
-  hosts: ["192.168.1.119:5044"]
+  hosts: ["172.17.0.1:5044"]

--- a/docker_field/images/metricbeat/Dockerfile
+++ b/docker_field/images/metricbeat/Dockerfile
@@ -1,5 +1,6 @@
-ARG elastic_stack
-FROM docker.elastic.co/beats/metricbeat:${elastic_stack}
+ARG elastic_version
+FROM docker.elastic.co/beats/metricbeat:${elastic_version}
 COPY config/metricbeat.yml /usr/share/metricbeat/metricbeat.yml
 USER root
 RUN chown root:metricbeat /usr/share/metricbeat/metricbeat.yml
+RUN chmod go-w            /usr/share/metricbeat/metricbeat.yml

--- a/docker_field/images/metricbeat/config/metricbeat.yml
+++ b/docker_field/images/metricbeat/config/metricbeat.yml
@@ -32,4 +32,4 @@ metricbeat.modules:
   enabled: true
 
 output.logstash:
-  hosts: ["192.168.1.119:5045"]
+  hosts: ["172.17.0.1:5045"]

--- a/docker_field/images/metricbeat/config/metricbeat.yml
+++ b/docker_field/images/metricbeat/config/metricbeat.yml
@@ -33,3 +33,5 @@ metricbeat.modules:
 
 output.logstash:
   hosts: ["172.17.0.1:5045"]
+
+setup.ilm.overwrite: true

--- a/docker_field/topology/.env
+++ b/docker_field/topology/.env
@@ -1,1 +1,1 @@
-elastic_version=7.8.0
+elastic_version=7.8.1

--- a/docker_field/topology/.env
+++ b/docker_field/topology/.env
@@ -1,0 +1,1 @@
+elastic_version=7.8.0

--- a/docker_field/topology/docker-compose.yml
+++ b/docker_field/topology/docker-compose.yml
@@ -14,18 +14,18 @@ services:
   filebeat:
     container_name: fbeat
     build:
-            context: ../images/filebeat
-            args:
-                    elastic_version: 7.8.0
+      context: ../images/filebeat
+      args:
+        - elastic_version
     volumes:
       - applicativeLogs:/usr/share/filebeat/logs
 
   metricbeat:
     container_name: mbeat
     build:
-            context: ../images/metricbeat
-            args:
-                    elastic_version: 7.8.0
+      context: ../images/metricbeat
+      args:
+        - elastic_version
     depends_on:
       - db
     volumes:
@@ -37,7 +37,6 @@ services:
     build: ../images/postgresql
     ports:
       - 5432:5432
-
 
 volumes:
   applicativeLogs:

--- a/docker_field/topology/start.sh
+++ b/docker_field/topology/start.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+docker-compose up --build -d
+docker-compose run metricbeat \
+	       metricbeat setup --index-management \
+	       -E output.logstash.enabled=false \
+	       -E 'output.elasticsearch.hosts=["172.17.0.1:9200"]'
+docker-compose logs -f


### PR DESCRIPTION
Fixes:

1. In `logstash.conf`: Rename index to "logstash" to match report document.
2. In metricbeat's `Dockerfile`: Fix file permission and env var name.
3. Add `docker_field/topology/start.sh`: after starting metricbeat, export template to elasticsearch. Otherwise some events from the 'Docker' module have parsing issues.
4. Use ELK v7.8.1. This fixes the issue: `org.elasticsearch.index.mapper.MapperParsingException: failed to parse field [docker.container.labels.org_opencontainers_image_created] of type [date] in document with id 'sndm3nMBdrSMxvucQ6Vy'. Preview of field's value: '2020-05-04 00:00:00+01:00'`
5. In filebeat and metricbeat configs: Change ELK host to 172.17.0.1 which is (on Linux) the native host seen from within a Docker container. Ideally we should use an environment variable and patch the configs at build in the Dockerfile. 

Cosmetic changes (arguably, a matter of taste):

1. As we do not modify the images of elasticsearch and kibana, use them w/o building and right away in `docker-compose.yml`. This means we don't need Dockerfiles for these services.
2. Define env vars in `.env` (for more flexibility). So they are defined in one place and can still be superseded by shell env vars.
3. Fix YAML indentation.
 
